### PR TITLE
Delete .scrutinizer.yml

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,0 @@
-build:
-    environment:
-        python: 3.6.1


### PR DESCRIPTION
Try to fix Scrutinizer's "There was an error" when configuring the Python runtime.